### PR TITLE
Feature/esphome 2025.11

### DIFF
--- a/components/truma_inetbox/LinBusListener.cpp
+++ b/components/truma_inetbox/LinBusListener.cpp
@@ -72,7 +72,7 @@ void LinBusListener::setup() {
 
 void LinBusListener::update() { this->check_for_lin_fault_(); }
 
-void LinBusListener::write_lin_answer_(const u_int8_t *data, u_int8_t len) {
+void LinBusListener::write_lin_answer_(const uint8_t *data, uint8_t len) {
   QUEUE_LOG_MSG log_msg = QUEUE_LOG_MSG();
   if (!this->can_write_lin_answer_) {
     log_msg.type = QUEUE_LOG_MSG_TYPE::ERROR_LIN_ANSWER_CAN_WRITE_LIN_ANSWER;
@@ -86,7 +86,7 @@ void LinBusListener::write_lin_answer_(const u_int8_t *data, u_int8_t len) {
     return;
   }
 
-  u_int8_t data_CRC = 0;
+  uint8_t data_CRC = 0;
   if (this->lin_checksum_ == LIN_CHECKSUM::LIN_CHECKSUM_VERSION_1 || this->current_PID_ == DIAGNOSTIC_FRAME_SLAVE) {
     // LIN checksum V1
     data_CRC = data_checksum(data, len, 0);
@@ -109,7 +109,7 @@ void LinBusListener::write_lin_answer_(const u_int8_t *data, u_int8_t len) {
 
   log_msg.type = QUEUE_LOG_MSG_TYPE::VERBOSE_LIN_ANSWER_RESPONSE;
   log_msg.current_PID = this->current_PID_;
-  for (u_int8_t i = 0; i < len; i++) {
+  for (uint8_t i = 0; i < len; i++) {
     log_msg.data[i] = data[i];
   }
   log_msg.data[len] = data_CRC;
@@ -162,7 +162,7 @@ void LinBusListener::onReceive_() {
 }
 
 void LinBusListener::read_lin_frame_() {
-  u_int8_t buf;
+  uint8_t buf;
   QUEUE_LOG_MSG log_msg = QUEUE_LOG_MSG();
 
   switch (this->current_state_) {
@@ -176,7 +176,7 @@ void LinBusListener::read_lin_frame_() {
             log_msg.type = QUEUE_LOG_MSG_TYPE::ERROR_READ_LIN_FRAME_UNABLE_TO_ANSWER;
           } else {
             log_msg.type = QUEUE_LOG_MSG_TYPE::ERROR_READ_LIN_FRAME_LOST_MSG;
-            for (u_int8_t i = 0; i < this->current_data_count_; i++) {
+            for (uint8_t i = 0; i < this->current_data_count_; i++) {
               log_msg.data[i] = this->current_data_[i];
             }
             log_msg.len = this->current_data_count_;
@@ -260,8 +260,8 @@ void LinBusListener::read_lin_frame_() {
   }
 
   if (this->current_state_ == READ_STATE_ACT && this->current_data_count_ > 1) {
-    u_int8_t data_length = this->current_data_count_ - 1;
-    u_int8_t data_CRC = this->current_data_[this->current_data_count_ - 1];
+    uint8_t data_length = this->current_data_count_ - 1;
+    uint8_t data_CRC = this->current_data_[this->current_data_count_ - 1];
     bool message_source_know = false;
     bool message_from_master = true;
 
@@ -280,8 +280,8 @@ void LinBusListener::read_lin_frame_() {
         message_from_master = false;
       }
     } else {
-      u_int8_t data_CRC_master = data_checksum(this->current_data_, data_length, this->current_PID_);
-      u_int8_t data_CRC_slave = data_checksum(this->current_data_, data_length, this->current_PID_with_parity_);
+      uint8_t data_CRC_master = data_checksum(this->current_data_, data_length, this->current_PID_);
+      uint8_t data_CRC_slave = data_checksum(this->current_data_, data_length, this->current_PID_with_parity_);
       if (data_CRC != data_CRC_master && data_CRC != data_CRC_slave) {
         log_msg.type = QUEUE_LOG_MSG_TYPE::WARN_READ_LIN_FRAME_LINv2_CRC;
         TRUMA_LOGW_ISR(log_msg);
@@ -296,7 +296,7 @@ void LinBusListener::read_lin_frame_() {
 #ifdef ESPHOME_LOG_HAS_VERBOSE
     log_msg.type = QUEUE_LOG_MSG_TYPE::VERBOSE_READ_LIN_FRAME_MSG;
     log_msg.current_PID = this->current_PID_;
-    for (u_int8_t i = 0; i < this->current_data_count_; i++) {
+    for (uint8_t i = 0; i < this->current_data_count_; i++) {
       log_msg.data[i] = this->current_data_[i];
     }
     log_msg.len = this->current_data_count_;
@@ -310,7 +310,7 @@ void LinBusListener::read_lin_frame_() {
       QUEUE_LIN_MSG lin_msg;
       lin_msg.current_PID = this->current_PID_;
       lin_msg.len = this->current_data_count_ - 1;
-      for (u_int8_t i = 0; i < lin_msg.len; i++) {
+      for (uint8_t i = 0; i < lin_msg.len; i++) {
         lin_msg.data[i] = this->current_data_[i];
       }
       xQueueSendFromISR(this->lin_msg_queue_, (void *) &lin_msg, QUEUE_WAIT_DONT_BLOCK);
@@ -320,7 +320,7 @@ void LinBusListener::read_lin_frame_() {
 }
 
 void LinBusListener::clear_uart_buffer_() {
-  u_int8_t buffer;
+  uint8_t buffer;
   while (this->available() && this->read_byte(&buffer)) {
   }
 }

--- a/components/truma_inetbox/LinBusListener.h
+++ b/components/truma_inetbox/LinBusListener.h
@@ -28,9 +28,9 @@ namespace truma_inetbox {
 enum class LIN_CHECKSUM { LIN_CHECKSUM_VERSION_1, LIN_CHECKSUM_VERSION_2 };
 
 struct QUEUE_LIN_MSG {
-  u_int8_t current_PID;
-  u_int8_t data[8];
-  u_int8_t len;
+  uint8_t current_PID;
+  uint8_t data[8];
+  uint8_t len;
 };
 
 class LinBusListener : public PollingComponent, public uart::UARTDevice {
@@ -52,7 +52,7 @@ class LinBusListener : public PollingComponent, public uart::UARTDevice {
 
 #ifdef USE_RP2040
   // Return is the expected wait time till next data check is recommended.
-  u_int32_t onSerialEvent();
+  uint32_t onSerialEvent();
 #endif  // USE_RP2040
 
  protected:
@@ -61,27 +61,27 @@ class LinBusListener : public PollingComponent, public uart::UARTDevice {
   GPIOPin *fault_pin_ = nullptr;
   bool observer_mode_ = false;
 
-  void write_lin_answer_(const u_int8_t *data, u_int8_t len);
+  void write_lin_answer_(const uint8_t *data, uint8_t len);
   bool check_for_lin_fault_();
-  virtual bool answer_lin_order_(const u_int8_t pid) = 0;
-  virtual void lin_message_recieved_(const u_int8_t pid, const u_int8_t *message, u_int8_t length) = 0;
+  virtual bool answer_lin_order_(const uint8_t pid) = 0;
+  virtual void lin_message_recieved_(const uint8_t pid, const uint8_t *message, uint8_t length) = 0;
 
  private:
   // Microseconds per UART Baud
-  u_int32_t time_per_baud_;
+  uint32_t time_per_baud_;
   // 9.. 15
-  const u_int8_t lin_break_length = 13;
+  const uint8_t lin_break_length = 13;
   // Microseconds per LIN Break
-  u_int32_t time_per_lin_break_;
-  const u_int8_t frame_length_ = (8 /* bits */ + 1 /* Start bit */ + 2 /* Stop bits */);
+  uint32_t time_per_lin_break_;
+  const uint8_t frame_length_ = (8 /* bits */ + 1 /* Start bit */ + 2 /* Stop bits */);
   // Microseconds per UART Byte (UART Frame)
-  u_int32_t time_per_pid_;
+  uint32_t time_per_pid_;
   // Microseconds per UART Byte (UART Frame)
-  u_int32_t time_per_first_byte_;
+  uint32_t time_per_first_byte_;
   // Microseconds per UART Byte (UART Frame)
-  u_int32_t time_per_byte_;
+  uint32_t time_per_byte_;
 
-  u_int8_t fault_on_lin_bus_reported_ = 0;
+  uint8_t fault_on_lin_bus_reported_ = 0;
   bool can_write_lin_answer_ = false;
 
   enum read_state {
@@ -92,13 +92,13 @@ class LinBusListener : public PollingComponent, public uart::UARTDevice {
     READ_STATE_ACT,
   };
   read_state current_state_ = READ_STATE_BREAK;
-  u_int8_t current_PID_with_parity_ = 0x00;
-  u_int8_t current_PID_ = 0x00;
+  uint8_t current_PID_with_parity_ = 0x00;
+  uint8_t current_PID_ = 0x00;
   bool current_PID_order_answered_ = false;
   bool current_data_valid = true;
-  u_int8_t current_data_count_ = 0;
+  uint8_t current_data_count_ = 0;
   // up to 8 byte data frame + CRC
-  u_int8_t current_data_[9] = {};
+  uint8_t current_data_[9] = {};
   // // Time when the last LIN data was available.
   uint32_t last_data_recieved_ = 0;
 
@@ -141,7 +141,7 @@ class LinBusListener : public PollingComponent, public uart::UARTDevice {
   static void uartEventTask_(void *args);
 #endif  // USE_ESP32_FRAMEWORK_ESP_IDF
 #ifdef USE_RP2040
-  u_int8_t uart_number_ = 0;
+  uint8_t uart_number_ = 0;
   uart_inst_t *uart_ = nullptr;
 #endif  // USE_RP2040
 };

--- a/components/truma_inetbox/LinBusListener_esp32_arduino.cpp
+++ b/components/truma_inetbox/LinBusListener_esp32_arduino.cpp
@@ -17,7 +17,7 @@ namespace truma_inetbox {
 
 static const char *const TAG = "truma_inetbox.LinBusListener";
 
-#define QUEUE_WAIT_BLOCKING (portTickType) portMAX_DELAY
+#define QUEUE_WAIT_BLOCKING (TickType_t) portMAX_DELAY
 
 void LinBusListener::setup_framework() {
   auto uartComp = static_cast<ESPHOME_UART *>(this->parent_);

--- a/components/truma_inetbox/LinBusListener_esp_idf.cpp
+++ b/components/truma_inetbox/LinBusListener_esp_idf.cpp
@@ -15,7 +15,7 @@ namespace truma_inetbox {
 
 static const char *const TAG = "truma_inetbox.LinBusListener";
 
-#define QUEUE_WAIT_BLOCKING (portTickType) portMAX_DELAY
+#define QUEUE_WAIT_BLOCKING (TickType_t) portMAX_DELAY
 
 void LinBusListener::setup_framework() {
   // uartSetFastReading

--- a/components/truma_inetbox/LinBusListener_esp_idf.cpp
+++ b/components/truma_inetbox/LinBusListener_esp_idf.cpp
@@ -21,7 +21,7 @@ void LinBusListener::setup_framework() {
   // uartSetFastReading
   auto uartComp = static_cast<ESPHOME_UART *>(this->parent_);
 
-  auto uart_num = uartComp->get_hw_serial_number();
+  uart_port_t uart_num = static_cast<uart_port_t>(uartComp->get_hw_serial_number());
 
   // Tweak the fifo settings so data is available as soon as the first byte is recieved.
   // If not it will wait either until fifo is filled or a certain time has passed.

--- a/components/truma_inetbox/LinBusListener_rp2040.cpp
+++ b/components/truma_inetbox/LinBusListener_rp2040.cpp
@@ -49,7 +49,7 @@ void LinBusListener::setup_framework() {
   }
 }
 
-u_int32_t LinBusListener::onSerialEvent() {
+uint32_t LinBusListener::onSerialEvent() {
   this->onReceive_();
 
   if (this->uart_ != nullptr) {
@@ -97,8 +97,8 @@ extern void loop1() {
     // Wait for setup_framework to finish.
     delay(100);
   } else {
-    u_int32_t sleep1 = 0xFFFFFFFF;
-    u_int32_t sleep2 = 0xFFFFFFFF;
+    uint32_t sleep1 = 0xFFFFFFFF;
+    uint32_t sleep2 = 0xFFFFFFFF;
     if (LIN_BUS_LISTENER_INSTANCE_1 != nullptr) {
       sleep1 = LIN_BUS_LISTENER_INSTANCE_1->onSerialEvent();
     }

--- a/components/truma_inetbox/LinBusLog.h
+++ b/components/truma_inetbox/LinBusLog.h
@@ -66,9 +66,9 @@ enum class QUEUE_LOG_MSG_TYPE {
 // Log messages generated during interrupt are pushed to log queue.
 struct QUEUE_LOG_MSG {
   QUEUE_LOG_MSG_TYPE type;
-  u_int8_t current_PID;
-  u_int8_t data[9];
-  u_int8_t len;
+  uint8_t current_PID;
+  uint8_t data[9];
+  uint8_t len;
 #ifdef ESPHOME_LOG_HAS_VERBOSE
   bool current_data_valid;
   bool message_source_know;

--- a/components/truma_inetbox/LinBusProtocol.cpp
+++ b/components/truma_inetbox/LinBusProtocol.cpp
@@ -26,26 +26,26 @@ void LinBusProtocol::lin_reset_device(){
   }
 }
 
-bool LinBusProtocol::answer_lin_order_(const u_int8_t pid) {
+bool LinBusProtocol::answer_lin_order_(const uint8_t pid) {
   // Send requested answer
   if (pid == DIAGNOSTIC_FRAME_SLAVE) {
     if (!this->updates_to_send_.empty()) {
       auto update_to_send_ = this->updates_to_send_.front();
       this->updates_to_send_.pop();
-      this->write_lin_answer_(update_to_send_.data(), (u_int8_t) update_to_send_.size());
+      this->write_lin_answer_(update_to_send_.data(), (uint8_t) update_to_send_.size());
       return true;
     }
   }
   return false;
 }
 
-void LinBusProtocol::lin_message_recieved_(const u_int8_t pid, const u_int8_t *message, u_int8_t length) {
+void LinBusProtocol::lin_message_recieved_(const uint8_t pid, const uint8_t *message, uint8_t length) {
   if (pid == DIAGNOSTIC_FRAME_MASTER) {
     // The original Inet Box is answering this message. Works fine without.
-    // std::array<u_int8_t, 8> message_array = {};
+    // std::array<uint8_t, 8> message_array = {};
     // std::copy(message, message + length, message_array.begin());
     // if (message_array == this->lin_empty_response_) {
-    //   std::array<u_int8_t, 8> response = this->lin_empty_response_;
+    //   std::array<uint8_t, 8> response = this->lin_empty_response_;
     //   response[0] = 0x00;
     //   response[1] = 0x55;
     //   response[2] = 0x03;  // this->lin_node_address_;
@@ -65,7 +65,7 @@ void LinBusProtocol::lin_message_recieved_(const u_int8_t pid, const u_int8_t *m
         return;
       }
     }
-    u_int8_t protocol_control_information = message[1];
+    uint8_t protocol_control_information = message[1];
     if ((protocol_control_information & 0xF0) == 0x00) {
       // Single Frame mode
       {
@@ -90,19 +90,19 @@ void LinBusProtocol::lin_message_recieved_(const u_int8_t pid, const u_int8_t *m
   }
 }
 
-bool LinBusProtocol::is_matching_identifier_(const u_int8_t *message) {
+bool LinBusProtocol::is_matching_identifier_(const uint8_t *message) {
   auto lin_identifier = this->lin_identifier();
   return message[0] == lin_identifier[0] && message[1] == lin_identifier[1] && message[2] == lin_identifier[2] &&
          message[3] == lin_identifier[3];
 }
 
-void LinBusProtocol::lin_msg_diag_single_(const u_int8_t *message, u_int8_t length) {
+void LinBusProtocol::lin_msg_diag_single_(const uint8_t *message, uint8_t length) {
   // auto node_address = message[0];
   bool my_node_address = message[0] == this->lin_node_address_;
   bool broadcast_address = message[0] == LIN_NAD_BROADCAST;
 
-  u_int8_t message_length = message[1];
-  u_int8_t service_identifier = message[2];
+  uint8_t message_length = message[1];
+  uint8_t service_identifier = message[2];
   if (message_length > 6) {
     ESP_LOGE(TAG, "LIN Protocol issue: Single frame message too long.");
     // ignore invalid message
@@ -118,10 +118,10 @@ void LinBusProtocol::lin_msg_diag_single_(const u_int8_t *message, u_int8_t leng
       // - 0x20 - displayed version
       // - 0x22 - unknown
       auto identifier = message[3];
-      std::array<u_int8_t, 8> response = this->lin_empty_response_;
+      std::array<uint8_t, 8> response = this->lin_empty_response_;
       response[0] = this->lin_node_address_;
 
-      std::array<u_int8_t, 5> identifier_response = {};
+      std::array<uint8_t, 5> identifier_response = {};
       if (this->lin_read_field_by_identifier_(identifier, &identifier_response)) {
         response[1] = 6; /* bytes length - ignored by CP Plus?*/
         response[2] = LIN_SID_READ_BY_IDENTIFIER_RESPONSE;
@@ -139,7 +139,7 @@ void LinBusProtocol::lin_msg_diag_single_(const u_int8_t *message, u_int8_t leng
     }
   } else if (my_node_address && service_identifier == LIN_SID_HEARTBEAT && message_length >= 5) {
     // if (message[3] == 0x00 && message[4] == 0x1F && message[5] == 0x00 && message[6] == 0x00) {
-    std::array<u_int8_t, 8> response = this->lin_empty_response_;
+    std::array<uint8_t, 8> response = this->lin_empty_response_;
     response[0] = this->lin_node_address_;
     response[1] = 2; /* bytes length*/
     response[2] = LIN_SID_HEARTBEAT_RESPONSE;
@@ -153,7 +153,7 @@ void LinBusProtocol::lin_msg_diag_single_(const u_int8_t *message, u_int8_t leng
       ESP_LOGI(TAG, "Assigned new SID %02X", message[7]);
 
       // send response with old node address.
-      std::array<u_int8_t, 8> response = this->lin_empty_response_;
+      std::array<uint8_t, 8> response = this->lin_empty_response_;
       response[0] = this->lin_node_address_;
       response[1] = 1; /* bytes length*/
       response[2] = LIN_SID_ASSIGN_NAD_RESPONSE;
@@ -170,9 +170,9 @@ void LinBusProtocol::lin_msg_diag_single_(const u_int8_t *message, u_int8_t leng
   }
 }
 
-void LinBusProtocol::lin_msg_diag_first_(const u_int8_t *message, u_int8_t length) {
-  u_int8_t protocol_control_information = message[1];
-  u_int16_t message_length = (protocol_control_information & 0x0F << 8) + message[2];
+void LinBusProtocol::lin_msg_diag_first_(const uint8_t *message, uint8_t length) {
+  uint8_t protocol_control_information = message[1];
+  uint16_t message_length = (protocol_control_information & 0x0F << 8) + message[2];
   if (message_length < 7) {
     ESP_LOGE(TAG, "LIN Protocol issue: Multi frame message too short.");
     // ignore invalid message
@@ -193,13 +193,13 @@ void LinBusProtocol::lin_msg_diag_first_(const u_int8_t *message, u_int8_t lengt
   }
 }
 
-bool LinBusProtocol::lin_msg_diag_consecutive_(const u_int8_t *message, u_int8_t length) {
+bool LinBusProtocol::lin_msg_diag_consecutive_(const uint8_t *message, uint8_t length) {
   if (this->multi_pdu_message_len_ >= this->multi_pdu_message_expected_size_) {
     // ignore, because i don't await a consecutive frame
     return false;
   }
-  u_int8_t protocol_control_information = message[1];
-  u_int8_t frame_counter = protocol_control_information & 0x0F;
+  uint8_t protocol_control_information = message[1];
+  uint8_t frame_counter = protocol_control_information & 0x0F;
   if (frame_counter != this->multi_pdu_message_frame_counter_) {
     // ignore, because i don't await this consecutive frame
     return false;
@@ -211,7 +211,7 @@ bool LinBusProtocol::lin_msg_diag_consecutive_(const u_int8_t *message, u_int8_t
   }
 
   // Copy recieved message over to `multi_pdu_message_` buffer.
-  for (u_int8_t i = 2; i < 8; i++) {
+  for (uint8_t i = 2; i < 8; i++) {
     if (this->multi_pdu_message_len_ < this->multi_pdu_message_expected_size_) {
       this->multi_pdu_message_[this->multi_pdu_message_len_++] = message[i];
     }
@@ -225,19 +225,19 @@ void LinBusProtocol::lin_msg_diag_multi_() {
   ESP_LOGD(TAG, "Multi package request  %s",
            format_hex_pretty(this->multi_pdu_message_, this->multi_pdu_message_len_).c_str());
 
-  u_int8_t answer_len = 0;
+  uint8_t answer_len = 0;
   // Ask handling class what to answer to this request.
   auto answer = this->lin_multiframe_recieved(this->multi_pdu_message_, this->multi_pdu_message_len_, &answer_len);
   if (answer_len > 0) {
     ESP_LOGD(TAG, "Multi package response %s", format_hex_pretty(answer, answer_len).c_str());
 
-    std::array<u_int8_t, 8> response = this->lin_empty_response_;
+    std::array<uint8_t, 8> response = this->lin_empty_response_;
     if (answer_len <= 6) {
       // Single Frame response - first frame
       response[0] = this->lin_node_address_;
       response[1] = answer_len; /* bytes length */
       response[2] = answer[0] | LIN_SID_RESPONSE;
-      for (u_int8_t i = 1; i < answer_len; i++) {
+      for (uint8_t i = 1; i < answer_len; i++) {
         response[i + 2] = answer[i];
       }
       this->prepare_update_msg_(response);
@@ -247,19 +247,19 @@ void LinBusProtocol::lin_msg_diag_multi_() {
       response[1] = 0x10 | ((answer_len >> 8) & 0x0F);
       response[2] = answer_len & 0xFF;
       response[3] = answer[0] | LIN_SID_RESPONSE;
-      for (u_int8_t i = 1; i < 5; i++) {
+      for (uint8_t i = 1; i < 5; i++) {
         response[i + 3] = answer[i];
       }
       this->prepare_update_msg_(response);
 
       // Multi Frame response - consecutive frame
-      u_int16_t answer_position = 5;      // The first 5 bytes are sent in First frame of multi frame response.
-      u_int8_t answer_frame_counter = 0;  // Each answer frame can contain 6 bytes
+      uint16_t answer_position = 5;      // The first 5 bytes are sent in First frame of multi frame response.
+      uint8_t answer_frame_counter = 0;  // Each answer frame can contain 6 bytes
       while (answer_position < answer_len) {
         response = this->lin_empty_response_;
         response[0] = this->lin_node_address_;
         response[1] = ((answer_frame_counter + 1) & 0x0F) | 0x20;
-        for (u_int8_t i = 0; i < 6; i++) {
+        for (uint8_t i = 0; i < 6; i++) {
           if (answer_position < answer_len) {
             response[i + 2] = answer[answer_position++];
           }

--- a/components/truma_inetbox/LinBusProtocol.h
+++ b/components/truma_inetbox/LinBusProtocol.h
@@ -7,35 +7,35 @@ namespace esphome {
 namespace truma_inetbox {
 class LinBusProtocol : public LinBusListener {
  public:
-  virtual const std::array<u_int8_t, 4> lin_identifier() = 0;
+  virtual const std::array<uint8_t, 4> lin_identifier() = 0;
   virtual void lin_heartbeat() = 0;
   virtual void lin_reset_device();
 
  protected:
-  const std::array<u_int8_t, 8> lin_empty_response_ = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+  const std::array<uint8_t, 8> lin_empty_response_ = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
 
-  bool answer_lin_order_(const u_int8_t pid) override;
-  void lin_message_recieved_(const u_int8_t pid, const u_int8_t *message, u_int8_t length) override;
+  bool answer_lin_order_(const uint8_t pid) override;
+  void lin_message_recieved_(const uint8_t pid, const uint8_t *message, uint8_t length) override;
 
-  virtual bool lin_read_field_by_identifier_(u_int8_t identifier, std::array<u_int8_t, 5> *response) = 0;
-  virtual const u_int8_t *lin_multiframe_recieved(const u_int8_t *message, const u_int8_t message_len,
-                                                  u_int8_t *return_len) = 0;
+  virtual bool lin_read_field_by_identifier_(uint8_t identifier, std::array<uint8_t, 5> *response) = 0;
+  virtual const uint8_t *lin_multiframe_recieved(const uint8_t *message, const uint8_t message_len,
+                                                  uint8_t *return_len) = 0;
 
-  std::queue<std::array<u_int8_t, 8>> updates_to_send_ = {};
+  std::queue<std::array<uint8_t, 8>> updates_to_send_ = {};
 
  private:
-  u_int8_t lin_node_address_ = /*LIN initial node address*/ 0x03;
+  uint8_t lin_node_address_ = /*LIN initial node address*/ 0x03;
 
-  void prepare_update_msg_(const std::array<u_int8_t, 8> message) { this->updates_to_send_.push(std::move(message)); }
-  bool is_matching_identifier_(const u_int8_t *message);
+  void prepare_update_msg_(const std::array<uint8_t, 8> message) { this->updates_to_send_.push(std::move(message)); }
+  bool is_matching_identifier_(const uint8_t *message);
 
-  u_int16_t multi_pdu_message_expected_size_ = 0;
-  u_int8_t multi_pdu_message_len_ = 0;
-  u_int8_t multi_pdu_message_frame_counter_ = 0;
-  u_int8_t multi_pdu_message_[64];
-  void lin_msg_diag_single_(const u_int8_t *message, u_int8_t length);
-  void lin_msg_diag_first_(const u_int8_t *message, u_int8_t length);
-  bool lin_msg_diag_consecutive_(const u_int8_t *message, u_int8_t length);
+  uint16_t multi_pdu_message_expected_size_ = 0;
+  uint8_t multi_pdu_message_len_ = 0;
+  uint8_t multi_pdu_message_frame_counter_ = 0;
+  uint8_t multi_pdu_message_[64];
+  void lin_msg_diag_single_(const uint8_t *message, uint8_t length);
+  void lin_msg_diag_first_(const uint8_t *message, uint8_t length);
+  bool lin_msg_diag_consecutive_(const uint8_t *message, uint8_t length);
   void lin_msg_diag_multi_();
 };
 

--- a/components/truma_inetbox/TrumaEnums.h
+++ b/components/truma_inetbox/TrumaEnums.h
@@ -5,7 +5,7 @@
 namespace esphome {
 namespace truma_inetbox {
 
-enum class HeatingMode : u_int16_t {
+enum class HeatingMode : uint16_t {
   HEATING_MODE_OFF = 0x0,
   // COMBI
   HEATING_MODE_ECO = 0x1,
@@ -28,13 +28,13 @@ enum class HeatingMode : u_int16_t {
   // FF00
 };
 
-enum class ElectricPowerLevel : u_int16_t {
+enum class ElectricPowerLevel : uint16_t {
   ELECTRIC_POWER_LEVEL_0 = 0,
   ELECTRIC_POWER_LEVEL_900 = 900,
   ELECTRIC_POWER_LEVEL_1800 = 1800,
 };
 
-enum class TargetTemp : u_int16_t {
+enum class TargetTemp : uint16_t {
   TARGET_TEMP_OFF = 0x0,
 
   // 40C
@@ -82,7 +82,7 @@ enum class TargetTemp : u_int16_t {
   TARGET_TEMP_AIRCON_AUTO_MAX = (25 + 273) * 10,
 };
 
-enum class EnergyMix : u_int8_t {
+enum class EnergyMix : uint8_t {
   ENERGY_MIX_NONE = 0b00,
   ENERGY_MIX_GAS = 0b01,
   ENERGY_MIX_DIESEL = 0b01,
@@ -90,7 +90,7 @@ enum class EnergyMix : u_int8_t {
   ENERGY_MIX_MIX = 0b11,
 };
 
-enum class OperatingStatus : u_int8_t {
+enum class OperatingStatus : uint8_t {
   OPERATING_STATUS_UNSET = 0x0,
   OPERATING_STATUS_OFF = 0x0,
   OPERATING_STATUS_WARNING = 0x1,
@@ -103,49 +103,49 @@ enum class OperatingStatus : u_int8_t {
   OPERATING_STATUS_ON_9 = 0x9,
 };
 
-enum class OperatingUnits : u_int8_t {
+enum class OperatingUnits : uint8_t {
   OPERATING_UNITS_CELSIUS = 0x0,
   OPERATING_UNITS_FAHRENHEIT = 0x1,
 };
 
-enum class Language : u_int8_t {
+enum class Language : uint8_t {
   LANGUAGE_GERMAN = 0x0,
   LANGUAGE_ENGLISH = 0x1,
   LANGUAGE_FRENCH = 0x2,
   LANGUAGE_ITALY = 0x3,
 };
 
-enum class ResponseAckResult : u_int8_t {
+enum class ResponseAckResult : uint8_t {
   RESPONSE_ACK_RESULT_OKAY = 0x0,
   RESPONSE_ACK_RESULT_ERROR_INVALID_MSG = 0x2,
   // The response status frame `message_type` is unknown.
   RESPONSE_ACK_RESULT_ERROR_INVALID_ID = 0x3,
 };
 
-enum class ClockMode : u_int8_t {
+enum class ClockMode : uint8_t {
   CLOCK_MODE_24H = 0x0,
   CLOCK_MODE_12H = 0x1,
 };
 
-enum class TimerActive : u_int8_t {
+enum class TimerActive : uint8_t {
   TIMER_ACTIVE_ON = 0x1,
   TIMER_ACTIVE_OFF = 0x0,
 };
 
-enum class ClockSource : u_int8_t {
+enum class ClockSource : uint8_t {
   // Set by user
   CLOCK_SOURCE_MANUAL = 0x1,
   // Set by message
   CLOCK_SOURCE_PROG = 0x2,
 };
 
-enum class TRUMA_COMPANY : u_int8_t {
+enum class TRUMA_COMPANY : uint8_t {
   UNKNOWN = 0x00,
   TRUMA = 0x1E,
   ALDE = 0x1A,
 };
 
-enum class TRUMA_DEVICE : u_int8_t {
+enum class TRUMA_DEVICE : uint8_t {
   UNKNOWN = 0x00,
 
   // Saphir Compact AC
@@ -166,19 +166,19 @@ enum class TRUMA_DEVICE : u_int8_t {
   HEATER_COMBI6D = 0x06,
 };
 
-enum class TRUMA_DEVICE_STATE : u_int8_t {
+enum class TRUMA_DEVICE_STATE : uint8_t {
   OFFLINE = 0x00,
   ONLINE = 0x01,
 };
 
-enum class AirconMode : u_int8_t {
+enum class AirconMode : uint8_t {
   // Auto - 18 to 25
   OFF = 0x00,
   AC_VENTILATION = 0x04,
   AC_COOLING = 0x05,
 };
 
-enum class AirconOperation : u_int8_t {
+enum class AirconOperation : uint8_t {
   AC_ONLY = 0x71,
   // Heater and Aircon
   AUTO = 0x72,

--- a/components/truma_inetbox/TrumaStatusFrameBuilder.h
+++ b/components/truma_inetbox/TrumaStatusFrameBuilder.h
@@ -6,8 +6,8 @@
 namespace esphome {
 namespace truma_inetbox {
 
-inline void status_frame_create_empty(StatusFrame *response, u_int8_t message_type, u_int8_t message_length,
-                                      u_int8_t command_counter) {
+inline void status_frame_create_empty(StatusFrame *response, uint8_t message_type, uint8_t message_length,
+                                      uint8_t command_counter) {
   response->genericHeader.service_identifier = LIN_SID_READ_STATE_BUFFER | LIN_SID_RESPONSE;
   // Copy header over for this message.
   for (size_t i = 1; i < truma_message_header.size(); i++) {
@@ -25,7 +25,7 @@ inline void status_frame_calculate_checksum(StatusFrame *response) {
   response->genericHeader.checksum = data_checksum(&response->raw[10], sizeof(StatusFrame) - 10, 0);
 }
 
-inline void status_frame_create_init(StatusFrame *response, u_int8_t *response_len, u_int8_t command_counter) {
+inline void status_frame_create_init(StatusFrame *response, uint8_t *response_len, uint8_t command_counter) {
   status_frame_create_empty(response, STATUS_FRAME_RESPONSE_INIT_REQUEST, 0, command_counter);
 
   // Init frame is empty.

--- a/components/truma_inetbox/TrumaStausFrameResponseStorage.h
+++ b/components/truma_inetbox/TrumaStausFrameResponseStorage.h
@@ -26,7 +26,7 @@ class TrumaStausFrameResponseStorage : public TrumaStausFrameStorage<T>, public 
     TrumaStausFrameStorage<T>::set_status(val);
     this->update_status_stale_ = false;
   };
-  virtual void create_update_data(StatusFrame *response, u_int8_t *response_len, u_int8_t command_counter) = 0;
+  virtual void create_update_data(StatusFrame *response, uint8_t *response_len, uint8_t command_counter) = 0;
 
  protected:
   inline void update_submitted() {

--- a/components/truma_inetbox/TrumaStructs.h
+++ b/components/truma_inetbox/TrumaStructs.h
@@ -38,15 +38,15 @@ namespace truma_inetbox {
 
 struct StatusFrameHeader {  // NOLINT(altera-struct-pack-align)
   // sid
-  u_int8_t service_identifier;
-  u_int8_t header[10];
-  u_int8_t header_2;
-  u_int8_t header_3;
+  uint8_t service_identifier;
+  uint8_t header[10];
+  uint8_t header_2;
+  uint8_t header_3;
   // after checksum
-  u_int8_t message_length;
-  u_int8_t message_type;
-  u_int8_t command_counter;
-  u_int8_t checksum;
+  uint8_t message_length;
+  uint8_t message_type;
+  uint8_t command_counter;
+  uint8_t checksum;
 } __attribute__((packed));
 
 // Length 20 (0x14)
@@ -60,12 +60,12 @@ struct StatusFrameHeater {  // NOLINT(altera-struct-pack-align)
   EnergyMix energy_mix_a;
   // Ignored by response
   EnergyMix energy_mix_b;
-  u_int16_t current_temp_water;
-  u_int16_t current_temp_room;
+  uint16_t current_temp_water;
+  uint16_t current_temp_room;
   OperatingStatus operating_status;
-  u_int8_t error_code_low;
-  u_int8_t error_code_high;
-  u_int8_t heater_unknown_2;
+  uint8_t error_code_low;
+  uint8_t error_code_high;
+  uint8_t heater_unknown_2;
 } __attribute__((packed));
 
 // Length 12 (0x0C)
@@ -91,14 +91,14 @@ struct StatusFrameTimer {  // NOLINT(altera-struct-pack-align)
   EnergyMix timer_energy_mix_a;
   EnergyMix timer_energy_mix_b;
   // used by timer response message
-  u_int8_t unused[5];
-  u_int8_t timer_unknown_3;
-  u_int8_t timer_unknown_4;
+  uint8_t unused[5];
+  uint8_t timer_unknown_3;
+  uint8_t timer_unknown_4;
   TimerActive timer_active;
-  u_int8_t timer_start_minutes;
-  u_int8_t timer_start_hours;
-  u_int8_t timer_stop_minutes;
-  u_int8_t timer_stop_hours;
+  uint8_t timer_start_minutes;
+  uint8_t timer_start_hours;
+  uint8_t timer_stop_minutes;
+  uint8_t timer_stop_hours;
 } __attribute__((packed));
 
 // Length 13 (0x0D)
@@ -113,70 +113,70 @@ struct StatusFrameTimerResponse {  // NOLINT(altera-struct-pack-align)
   // set by response message to active timer
   TimerActive timer_resp_active;
   // set by response message to active timer
-  u_int8_t timer_resp_start_minutes;
+  uint8_t timer_resp_start_minutes;
   // set by response message to active timer
-  u_int8_t timer_resp_start_hours;
+  uint8_t timer_resp_start_hours;
   // set by response message to active timer
-  u_int8_t timer_resp_stop_minutes;
+  uint8_t timer_resp_stop_minutes;
   // set by response message to active timer
-  u_int8_t timer_resp_stop_hours;
+  uint8_t timer_resp_stop_hours;
 } __attribute__((packed));
 
 // Length 2 (0x02)
 struct StatusFrameResponseAck {  // NOLINT(altera-struct-pack-align)
   ResponseAckResult error_code;
-  u_int8_t unknown;
+  uint8_t unknown;
 } __attribute__((packed));
 
 // Length 10 (0x0A)
 struct StatusFrameClock {  // NOLINT(altera-struct-pack-align)
-  u_int8_t clock_hour;
-  u_int8_t clock_minute;
-  u_int8_t clock_second;
+  uint8_t clock_hour;
+  uint8_t clock_minute;
+  uint8_t clock_second;
   // MUST be 0x1, 0x2, 0x3..? (lower than 0x9)
-  u_int8_t display_1;
+  uint8_t display_1;
   // MUST be 0x1
-  u_int8_t display_2;
-  u_int8_t display_3;
+  uint8_t display_2;
+  uint8_t display_3;
   ClockMode clock_mode;
   ClockSource clock_source;
-  u_int8_t display_4;
-  u_int8_t display_5;
+  uint8_t display_4;
+  uint8_t display_5;
 } __attribute__((packed));
 
 // Length 10 (0x0A)
 struct StatusFrameConfig {  // NOLINT(altera-struct-pack-align)
   // 0x01 .. 0x0A
-  u_int8_t display_brightness;
+  uint8_t display_brightness;
   Language language;
   // Mit „AC SET“ wird ein Offset zwischen Kühlen und Heizen eingestellt.
   // Die Einstellung ist in Schritten von 0,5 °C im Bereich von 0 °C bis +5 °C möglich.
   TargetTemp ac_offset;
   TargetTemp temp_offset;
   OperatingUnits temp_units;
-  u_int8_t unknown_6;
-  u_int8_t unknown_7;
-  u_int8_t unknown_8;
+  uint8_t unknown_6;
+  uint8_t unknown_7;
+  uint8_t unknown_8;
 } __attribute__((packed));
 
 // Length 12 (0x0C)
 struct StatusFrameDevice {  // NOLINT(altera-struct-pack-align)
-  u_int8_t device_count;
-  u_int8_t device_id;
+  uint8_t device_count;
+  uint8_t device_id;
   TRUMA_DEVICE_STATE state;
   // 0x00
-  u_int8_t unknown_1;
-  u_int16_t hardware_revision_major;
-  u_int8_t hardware_revision_minor;
+  uint8_t unknown_1;
+  uint16_t hardware_revision_major;
+  uint8_t hardware_revision_minor;
   // `software_revision[0].software_revision[1].software_revision[2]`
   // software_revision[0] -> TRUMA_DEVICE
-  u_int8_t software_revision[3];
+  uint8_t software_revision[3];
   // 0xAD, 0x0B on CPplus with Combi4 or 0x66 on CPplus with Vario Heat Comfort ohne E
   // 0x00 on Combi4, Vario Heat
-  u_int8_t unknown_2;
+  uint8_t unknown_2;
   // 0x10, 0x12 on CPplus
   // 0x00 on Combi4, Vario Heat
-  u_int8_t unknown_3;
+  uint8_t unknown_3;
 } __attribute__((packed));
 
 // Length 18 (0x12)
@@ -184,32 +184,32 @@ struct StatusFrameDevice {  // NOLINT(altera-struct-pack-align)
 struct StatusFrameAirconManual {  // NOLINT(altera-struct-pack-align)
   AirconMode mode;
   // 0x00
-  u_int8_t unknown_02;
+  uint8_t unknown_02;
   AirconOperation operation;
   EnergyMix energy_mix;
   TargetTemp target_temp_aircon;
   // 0x00
-  u_int8_t unknown_07;
+  uint8_t unknown_07;
   // 0x00
-  u_int8_t unknown_08;
+  uint8_t unknown_08;
   // No idea why two current_temp
   TargetTemp current_temp_aircon;
   // 0x00
-  u_int8_t unknown_11;
+  uint8_t unknown_11;
   // 0x00
-  u_int8_t unknown_12;
+  uint8_t unknown_12;
   ElectricPowerLevel el_power_level;
   // 0x00
-  u_int8_t unknown_15;
+  uint8_t unknown_15;
   // 0x00
-  u_int8_t unknown_16;
+  uint8_t unknown_16;
   TargetTemp current_temp_room;
 } __attribute__((packed));
 
 struct StatusFrameAirconManualResponse {  // NOLINT(altera-struct-pack-align)
   AirconMode mode;
   // 0x00
-  u_int8_t unknown_02;
+  uint8_t unknown_02;
   AirconOperation operation;
   EnergyMix energy_mix;
   TargetTemp target_temp_aircon;
@@ -218,43 +218,43 @@ struct StatusFrameAirconManualResponse {  // NOLINT(altera-struct-pack-align)
 // Length 22 (0x16)
 // TODO
 struct StatusFrameAirconManualInit {  // NOLINT(altera-struct-pack-align)
-  u_int8_t unknown_01;                // 0x00
-  u_int8_t unknown_02;                // 0x00
+  uint8_t unknown_01;                // 0x00
+  uint8_t unknown_02;                // 0x00
   AirconOperation operation;
   EnergyMix energy_mix;
-  u_int8_t unknown_05;  // 0x00
-  u_int8_t unknown_06;  // 0x00
-  u_int8_t unknown_07;  // 0x00
-  u_int8_t unknown_08;  // 0x00
-  u_int8_t unknown_09;  // 0x00
-  u_int8_t unknown_10;  // 0x00
-  u_int8_t unknown_11;  // 0x00
-  u_int8_t unknown_12;  // 0x00
-  u_int8_t unknown_13;  // 0x00
-  u_int8_t unknown_14;  // 0x00
-  u_int8_t unknown_15;  // 0x00
-  u_int8_t unknown_16;  // 0x00
-  u_int8_t unknown_17;  // 0x00
-  u_int8_t unknown_18;  // 0x00
-  u_int8_t unknown_19;  // 0x00
-  u_int8_t unknown_20;  // 0x00
-  u_int8_t unknown_21;  // 0x00
-  u_int8_t unknown_22;  // 0x00
+  uint8_t unknown_05;  // 0x00
+  uint8_t unknown_06;  // 0x00
+  uint8_t unknown_07;  // 0x00
+  uint8_t unknown_08;  // 0x00
+  uint8_t unknown_09;  // 0x00
+  uint8_t unknown_10;  // 0x00
+  uint8_t unknown_11;  // 0x00
+  uint8_t unknown_12;  // 0x00
+  uint8_t unknown_13;  // 0x00
+  uint8_t unknown_14;  // 0x00
+  uint8_t unknown_15;  // 0x00
+  uint8_t unknown_16;  // 0x00
+  uint8_t unknown_17;  // 0x00
+  uint8_t unknown_18;  // 0x00
+  uint8_t unknown_19;  // 0x00
+  uint8_t unknown_20;  // 0x00
+  uint8_t unknown_21;  // 0x00
+  uint8_t unknown_22;  // 0x00
 } __attribute__((packed));
 
 // Length 18 (0x12)
 // TODO
 struct StatusFrameAirconAuto {  // NOLINT(altera-struct-pack-align)
   EnergyMix energy_mix_a;
-  u_int8_t unknown_02;  // 0x00
+  uint8_t unknown_02;  // 0x00
   EnergyMix energy_mix_b;
-  u_int8_t unknown_04;  // 0x00
-  u_int8_t unknown_05;  // 0x00
-  u_int8_t unknown_06;  // 0x00
+  uint8_t unknown_04;  // 0x00
+  uint8_t unknown_05;  // 0x00
+  uint8_t unknown_06;  // 0x00
   TargetTemp target_temp_aircon_auto;
   ElectricPowerLevel el_power_level_a;
-  u_int8_t unknown_11;  // 0x00
-  u_int8_t unknown_12;  // 0x00
+  uint8_t unknown_11;  // 0x00
+  uint8_t unknown_12;  // 0x00
   ElectricPowerLevel el_power_level_b;
   TargetTemp current_temp;
   TargetTemp target_temp;
@@ -263,15 +263,15 @@ struct StatusFrameAirconAuto {  // NOLINT(altera-struct-pack-align)
 // TODO
 struct StatusFrameAirconAutoResponse {  // NOLINT(altera-struct-pack-align)
   EnergyMix energy_mix_a;
-  u_int8_t unknown_02;  // 0x00
+  uint8_t unknown_02;  // 0x00
   EnergyMix energy_mix_b;
-  u_int8_t unknown_04;  // 0x00
-  u_int8_t unknown_05;  // 0x00
-  u_int8_t unknown_06;  // 0x00
+  uint8_t unknown_04;  // 0x00
+  uint8_t unknown_05;  // 0x00
+  uint8_t unknown_06;  // 0x00
   TargetTemp target_temp_aircon_auto;
   ElectricPowerLevel el_power_level_a;
-  u_int8_t unknown_11;  // 0x00
-  u_int8_t unknown_12;  // 0x00
+  uint8_t unknown_11;  // 0x00
+  uint8_t unknown_12;  // 0x00
   ElectricPowerLevel el_power_level_b;
 } __attribute__((packed));
 
@@ -279,29 +279,29 @@ struct StatusFrameAirconAutoResponse {  // NOLINT(altera-struct-pack-align)
 // TODO
 struct StatusFrameAirconAutoInit {  // NOLINT(altera-struct-pack-align)
   EnergyMix energy_mix_a;
-  u_int8_t unknown_02;  // 0x00
+  uint8_t unknown_02;  // 0x00
   EnergyMix energy_mix_b;
-  u_int8_t unknown_04;  // 0x00
-  u_int8_t unknown_05;  // 0x00
-  u_int8_t unknown_06;  // 0x00
-  u_int8_t unknown_07;  // 0x00
-  u_int8_t unknown_08;  // 0x00
-  u_int8_t unknown_09;  // 0x00
-  u_int8_t unknown_10;  // 0x00
-  u_int8_t unknown_11;  // 0x00
-  u_int8_t unknown_12;  // 0x00
-  u_int8_t unknown_13;  // 0x00
-  u_int8_t unknown_14;  // 0x00
-  u_int8_t unknown_15;  // 0x00
-  u_int8_t unknown_16;  // 0x00
-  u_int8_t unknown_17;  // 0x00
-  u_int8_t unknown_18;  // 0x00
-  u_int8_t unknown_19;  // 0x00
-  u_int8_t unknown_20;  // 0x00
+  uint8_t unknown_04;  // 0x00
+  uint8_t unknown_05;  // 0x00
+  uint8_t unknown_06;  // 0x00
+  uint8_t unknown_07;  // 0x00
+  uint8_t unknown_08;  // 0x00
+  uint8_t unknown_09;  // 0x00
+  uint8_t unknown_10;  // 0x00
+  uint8_t unknown_11;  // 0x00
+  uint8_t unknown_12;  // 0x00
+  uint8_t unknown_13;  // 0x00
+  uint8_t unknown_14;  // 0x00
+  uint8_t unknown_15;  // 0x00
+  uint8_t unknown_16;  // 0x00
+  uint8_t unknown_17;  // 0x00
+  uint8_t unknown_18;  // 0x00
+  uint8_t unknown_19;  // 0x00
+  uint8_t unknown_20;  // 0x00
 } __attribute__((packed));
 
 union StatusFrame {  // NOLINT(altera-struct-pack-align)
-  u_int8_t raw[41];
+  uint8_t raw[41];
   struct {  // NOLINT(altera-struct-pack-align)
     StatusFrameHeader genericHeader;
     union {  // NOLINT(altera-struct-pack-align)

--- a/components/truma_inetbox/TrumaiNetBoxApp.cpp
+++ b/components/truma_inetbox/TrumaiNetBoxApp.cpp
@@ -85,21 +85,21 @@ void TrumaiNetBoxApp::lin_reset_device() {
   this->update_time_ = 0;
 }
 
-bool TrumaiNetBoxApp::answer_lin_order_(const u_int8_t pid) {
+bool TrumaiNetBoxApp::answer_lin_order_(const uint8_t pid) {
   // Alive message
   if (pid == LIN_PID_TRUMA_INET_BOX) {
-    std::array<u_int8_t, 8> response = this->lin_empty_response_;
+    std::array<uint8_t, 8> response = this->lin_empty_response_;
 
     if (this->updates_to_send_.empty() && !this->has_update_to_submit_()) {
       response[0] = 0xFE;
     }
-    this->write_lin_answer_(response.data(), (u_int8_t) sizeof(response));
+    this->write_lin_answer_(response.data(), (uint8_t) sizeof(response));
     return true;
   }
   return LinBusProtocol::answer_lin_order_(pid);
 }
 
-bool TrumaiNetBoxApp::lin_read_field_by_identifier_(u_int8_t identifier, std::array<u_int8_t, 5> *response) {
+bool TrumaiNetBoxApp::lin_read_field_by_identifier_(uint8_t identifier, std::array<uint8_t, 5> *response) {
   if (identifier == 0x00 /* LIN Product Identification */) {
     auto lin_identifier = this->lin_identifier();
     (*response)[0] = lin_identifier[0];
@@ -125,19 +125,19 @@ bool TrumaiNetBoxApp::lin_read_field_by_identifier_(u_int8_t identifier, std::ar
   return false;
 }
 
-const u_int8_t *TrumaiNetBoxApp::lin_multiframe_recieved(const u_int8_t *message, const u_int8_t message_len,
-                                                         u_int8_t *return_len) {
-  static u_int8_t response[48] = {};
+const uint8_t *TrumaiNetBoxApp::lin_multiframe_recieved(const uint8_t *message, const uint8_t message_len,
+                                                         uint8_t *return_len) {
+  static uint8_t response[48] = {};
   // Validate message prefix.
   if (message_len < truma_message_header.size()) {
     return nullptr;
   }
-  for (u_int8_t i = 1; i < truma_message_header.size() - 3; i++) {
+  for (uint8_t i = 1; i < truma_message_header.size() - 3; i++) {
     if (message[i] != truma_message_header[i] && message[i] != alde_message_header[i]) {
       return nullptr;
     }
   }
-  if (message[4] != (u_int8_t) this->company_) {
+  if (message[4] != (uint8_t) this->company_) {
     ESP_LOGI(TAG, "Switch company to 0x%02x", message[4]);
     this->company_ = (TRUMA_COMPANY) message[4];
   }
@@ -295,7 +295,7 @@ const u_int8_t *TrumaiNetBoxApp::lin_multiframe_recieved(const u_int8_t *message
     }
     ESP_LOGD(TAG, "StatusFrameResponseAck %02X %s %02X", statusFrame->genericHeader.command_counter,
              data.error_code == ResponseAckResult::RESPONSE_ACK_RESULT_OKAY ? " OKAY " : " FAILED ",
-             (u_int8_t) data.error_code);
+             (uint8_t) data.error_code);
 
     if (data.error_code != ResponseAckResult::RESPONSE_ACK_RESULT_OKAY) {
       // I tried to update something and it failed. Read current state again to validate and hold any updates for now.

--- a/components/truma_inetbox/TrumaiNetBoxApp.h
+++ b/components/truma_inetbox/TrumaiNetBoxApp.h
@@ -23,7 +23,7 @@ class TrumaiNetBoxApp : public LinBusProtocol {
   TrumaiNetBoxApp();
   void update() override;
 
-  const std::array<u_int8_t, 4> lin_identifier() override;
+  const std::array<uint8_t, 4> lin_identifier() override;
   void lin_heartbeat() override;
   void lin_reset_device() override;
 
@@ -49,7 +49,7 @@ class TrumaiNetBoxApp : public LinBusProtocol {
   uint32_t device_registered_ = 0;
   uint32_t init_requested_ = 0;
   uint32_t init_recieved_ = 0;
-  u_int8_t message_counter = 1;
+  uint8_t message_counter = 1;
 
   // Truma heater conected to CP Plus.
   TRUMA_COMPANY company_ = TRUMA_COMPANY::TRUMA;
@@ -73,11 +73,11 @@ class TrumaiNetBoxApp : public LinBusProtocol {
   bool update_status_clock_done = false;
 #endif  // USE_TIME
 
-  bool answer_lin_order_(const u_int8_t pid) override;
+  bool answer_lin_order_(const uint8_t pid) override;
 
-  bool lin_read_field_by_identifier_(u_int8_t identifier, std::array<u_int8_t, 5> *response) override;
-  const u_int8_t *lin_multiframe_recieved(const u_int8_t *message, const u_int8_t message_len,
-                                          u_int8_t *return_len) override;
+  bool lin_read_field_by_identifier_(uint8_t identifier, std::array<uint8_t, 5> *response) override;
+  const uint8_t *lin_multiframe_recieved(const uint8_t *message, const uint8_t message_len,
+                                          uint8_t *return_len) override;
 
   bool has_update_to_submit_();
 };

--- a/components/truma_inetbox/TrumaiNetBoxAppAirconAuto.cpp
+++ b/components/truma_inetbox/TrumaiNetBoxAppAirconAuto.cpp
@@ -33,8 +33,8 @@ StatusFrameAirconAutoResponse *TrumaiNetBoxAppAirconAuto::update_prepare() {
   return &this->update_status_;
 }
 
-void TrumaiNetBoxAppAirconAuto::create_update_data(StatusFrame *response, u_int8_t *response_len,
-                                                   u_int8_t command_counter) {
+void TrumaiNetBoxAppAirconAuto::create_update_data(StatusFrame *response, uint8_t *response_len,
+                                                   uint8_t command_counter) {
   status_frame_create_empty(response, STATUS_FRAME_AIRCON_AUTO_RESPONSE, sizeof(StatusFrameAirconAutoResponse),
                             command_counter);
 

--- a/components/truma_inetbox/TrumaiNetBoxAppAirconAuto.h
+++ b/components/truma_inetbox/TrumaiNetBoxAppAirconAuto.h
@@ -10,7 +10,7 @@ class TrumaiNetBoxAppAirconAuto
     : public TrumaStausFrameResponseStorage<StatusFrameAirconAuto, StatusFrameAirconAutoResponse> {
  public:
   StatusFrameAirconAutoResponse *update_prepare() override;
-  void create_update_data(StatusFrame *response, u_int8_t *response_len, u_int8_t command_counter) override;
+  void create_update_data(StatusFrame *response, uint8_t *response_len, uint8_t command_counter) override;
   void dump_data() const override;
   bool can_update() override;
 };

--- a/components/truma_inetbox/TrumaiNetBoxAppAirconManual.cpp
+++ b/components/truma_inetbox/TrumaiNetBoxAppAirconManual.cpp
@@ -26,8 +26,8 @@ StatusFrameAirconManualResponse *TrumaiNetBoxAppAirconManual::update_prepare() {
   return &this->update_status_;
 }
 
-void TrumaiNetBoxAppAirconManual::create_update_data(StatusFrame *response, u_int8_t *response_len,
-                                                     u_int8_t command_counter) {
+void TrumaiNetBoxAppAirconManual::create_update_data(StatusFrame *response, uint8_t *response_len,
+                                                     uint8_t command_counter) {
   status_frame_create_empty(response, STATUS_FRAME_AIRCON_MANUAL_RESPONSE, sizeof(StatusFrameAirconManualResponse),
                             command_counter);
 
@@ -50,7 +50,7 @@ bool TrumaiNetBoxAppAirconManual::can_update() {
          this->parent_->get_aircon_device() != TRUMA_DEVICE::UNKNOWN;
 }
 
-bool TrumaiNetBoxAppAirconManual::action_set_temp(u_int8_t temperature) {
+bool TrumaiNetBoxAppAirconManual::action_set_temp(uint8_t temperature) {
   if (!this->can_update()) {
     ESP_LOGW(TAG, "Cannot update Truma.");
     return false;

--- a/components/truma_inetbox/TrumaiNetBoxAppAirconManual.h
+++ b/components/truma_inetbox/TrumaiNetBoxAppAirconManual.h
@@ -10,11 +10,11 @@ class TrumaiNetBoxAppAirconManual
     : public TrumaStausFrameResponseStorage<StatusFrameAirconManual, StatusFrameAirconManualResponse> {
  public:
   StatusFrameAirconManualResponse *update_prepare() override;
-  void create_update_data(StatusFrame *response, u_int8_t *response_len, u_int8_t command_counter) override;
+  void create_update_data(StatusFrame *response, uint8_t *response_len, uint8_t command_counter) override;
   void dump_data() const override;
   bool can_update() override;
 
-  bool action_set_temp(u_int8_t temperature);
+  bool action_set_temp(uint8_t temperature);
 };
 
 }  // namespace truma_inetbox

--- a/components/truma_inetbox/TrumaiNetBoxAppClock.cpp
+++ b/components/truma_inetbox/TrumaiNetBoxAppClock.cpp
@@ -39,7 +39,7 @@ bool TrumaiNetBoxAppClock::action_write_time() {
   return true;
 }
 
-void TrumaiNetBoxAppClock::create_update_data(StatusFrame *response, u_int8_t *response_len, u_int8_t command_counter) {
+void TrumaiNetBoxAppClock::create_update_data(StatusFrame *response, uint8_t *response_len, uint8_t command_counter) {
   if (this->parent_->get_time() != nullptr) {
     ESP_LOGD(TAG, "Requested read: Sending clock update");
     // read time live

--- a/components/truma_inetbox/TrumaiNetBoxAppClock.h
+++ b/components/truma_inetbox/TrumaiNetBoxAppClock.h
@@ -16,7 +16,7 @@ class TrumaiNetBoxAppClock : public TrumaStausFrameStorage<StatusFrameClock>, pu
   void update_submit() { this->update_status_unsubmitted_ = true; }
   bool has_update() const { return this->update_status_unsubmitted_; }
   bool action_write_time();
-  void create_update_data(StatusFrame *response, u_int8_t *response_len, u_int8_t command_counter);
+  void create_update_data(StatusFrame *response, uint8_t *response_len, uint8_t command_counter);
 
  protected:
   // The behaviour of `update_status_clock_unsubmitted_` is special.

--- a/components/truma_inetbox/TrumaiNetBoxAppHeater.cpp
+++ b/components/truma_inetbox/TrumaiNetBoxAppHeater.cpp
@@ -29,8 +29,8 @@ StatusFrameHeaterResponse *TrumaiNetBoxAppHeater::update_prepare() {
   return &this->update_status_;
 }
 
-void TrumaiNetBoxAppHeater::create_update_data(StatusFrame *response, u_int8_t *response_len,
-                                               u_int8_t command_counter) {
+void TrumaiNetBoxAppHeater::create_update_data(StatusFrame *response, uint8_t *response_len,
+                                               uint8_t command_counter) {
   status_frame_create_empty(response, STATUS_FRAME_HEATER_RESPONSE, sizeof(StatusFrameHeaterResponse), command_counter);
 
   response->heaterResponse.target_temp_room = this->update_status_.target_temp_room;
@@ -54,7 +54,7 @@ bool TrumaiNetBoxAppHeater::can_update() {
          this->parent_->get_heater_device() != TRUMA_DEVICE::UNKNOWN;
 }
 
-bool TrumaiNetBoxAppHeater::action_heater_room(u_int8_t temperature, HeatingMode mode) {
+bool TrumaiNetBoxAppHeater::action_heater_room(uint8_t temperature, HeatingMode mode) {
   if (!this->can_update()) {
     ESP_LOGW(TAG, "Cannot update Truma.");
     return false;
@@ -94,7 +94,7 @@ bool TrumaiNetBoxAppHeater::action_heater_room(u_int8_t temperature, HeatingMode
   return true;
 }
 
-bool TrumaiNetBoxAppHeater::action_heater_water(u_int8_t temperature) {
+bool TrumaiNetBoxAppHeater::action_heater_water(uint8_t temperature) {
   if (!this->can_update()) {
     ESP_LOGW(TAG, "Cannot update Truma.");
     return false;
@@ -136,7 +136,7 @@ bool TrumaiNetBoxAppHeater::action_heater_water(TargetTemp temperature) {
   return true;
 }
 
-bool TrumaiNetBoxAppHeater::action_heater_electric_power_level(u_int16_t value) {
+bool TrumaiNetBoxAppHeater::action_heater_electric_power_level(uint16_t value) {
   if (!this->can_update()) {
     ESP_LOGW(TAG, "Cannot update Truma.");
     return false;

--- a/components/truma_inetbox/TrumaiNetBoxAppHeater.h
+++ b/components/truma_inetbox/TrumaiNetBoxAppHeater.h
@@ -9,14 +9,14 @@ namespace truma_inetbox {
 class TrumaiNetBoxAppHeater : public TrumaStausFrameResponseStorage<StatusFrameHeater, StatusFrameHeaterResponse> {
  public:
   StatusFrameHeaterResponse *update_prepare() override;
-  void create_update_data(StatusFrame *response, u_int8_t *response_len, u_int8_t command_counter) override;
+  void create_update_data(StatusFrame *response, uint8_t *response_len, uint8_t command_counter) override;
   void dump_data() const override;
   bool can_update() override;
 
-  bool action_heater_room(u_int8_t temperature, HeatingMode mode = HeatingMode::HEATING_MODE_OFF);
-  bool action_heater_water(u_int8_t temperature);
+  bool action_heater_room(uint8_t temperature, HeatingMode mode = HeatingMode::HEATING_MODE_OFF);
+  bool action_heater_water(uint8_t temperature);
   bool action_heater_water(TargetTemp temperature);
-  bool action_heater_electric_power_level(u_int16_t value);
+  bool action_heater_electric_power_level(uint16_t value);
   bool action_heater_energy_mix(EnergyMix energy_mix,
                                 ElectricPowerLevel el_power_level = ElectricPowerLevel::ELECTRIC_POWER_LEVEL_0);
 };

--- a/components/truma_inetbox/TrumaiNetBoxAppTimer.cpp
+++ b/components/truma_inetbox/TrumaiNetBoxAppTimer.cpp
@@ -34,7 +34,7 @@ StatusFrameTimerResponse *TrumaiNetBoxAppTimer::update_prepare() {
   return &this->update_status_;
 }
 
-void TrumaiNetBoxAppTimer::create_update_data(StatusFrame *response, u_int8_t *response_len, u_int8_t command_counter) {
+void TrumaiNetBoxAppTimer::create_update_data(StatusFrame *response, uint8_t *response_len, uint8_t command_counter) {
   status_frame_create_empty(response, STATUS_FRAME_TIMER_RESPONSE, sizeof(StatusFrameTimerResponse), command_counter);
 
   response->timerResponse.timer_target_temp_room = this->update_status_.timer_target_temp_room;
@@ -61,7 +61,7 @@ void TrumaiNetBoxAppTimer::dump_data() const {
            temp_code_to_decimal(this->data_.timer_target_temp_room),
            temp_code_to_decimal(this->data_.timer_target_temp_water), this->data_.timer_start_hours,
            this->data_.timer_start_minutes, this->data_.timer_stop_hours, this->data_.timer_stop_minutes,
-           ((u_int8_t) this->data_.timer_active ? " ON" : " OFF"));
+           ((uint8_t) this->data_.timer_active ? " ON" : " OFF"));
 }
 
 bool TrumaiNetBoxAppTimer::action_timer_disable() {
@@ -77,8 +77,8 @@ bool TrumaiNetBoxAppTimer::action_timer_disable() {
   return true;
 }
 
-bool TrumaiNetBoxAppTimer::action_timer_activate(u_int16_t start, u_int16_t stop, u_int8_t room_temperature,
-                                                 HeatingMode mode, u_int8_t water_temperature, EnergyMix energy_mix,
+bool TrumaiNetBoxAppTimer::action_timer_activate(uint16_t start, uint16_t stop, uint8_t room_temperature,
+                                                 HeatingMode mode, uint8_t water_temperature, EnergyMix energy_mix,
                                                  ElectricPowerLevel el_power_level) {
   if (!this->can_update()) {
     ESP_LOGW(TAG, "Cannot update Truma.");

--- a/components/truma_inetbox/TrumaiNetBoxAppTimer.h
+++ b/components/truma_inetbox/TrumaiNetBoxAppTimer.h
@@ -9,12 +9,12 @@ namespace truma_inetbox {
 class TrumaiNetBoxAppTimer : public TrumaStausFrameResponseStorage<StatusFrameTimer, StatusFrameTimerResponse> {
  public:
   StatusFrameTimerResponse *update_prepare() override;
-  void create_update_data(StatusFrame *response, u_int8_t *response_len, u_int8_t command_counter) override;
+  void create_update_data(StatusFrame *response, uint8_t *response_len, uint8_t command_counter) override;
   void dump_data() const override;
   
   bool action_timer_disable();
-  bool action_timer_activate(u_int16_t start, u_int16_t stop, u_int8_t room_temperature,
-                             HeatingMode mode = HeatingMode::HEATING_MODE_OFF, u_int8_t water_temperature = 0,
+  bool action_timer_activate(uint16_t start, uint16_t stop, uint8_t room_temperature,
+                             HeatingMode mode = HeatingMode::HEATING_MODE_OFF, uint8_t water_temperature = 0,
                              EnergyMix energy_mix = EnergyMix::ENERGY_MIX_NONE,
                              ElectricPowerLevel el_power_level = ElectricPowerLevel::ELECTRIC_POWER_LEVEL_0);
 };

--- a/components/truma_inetbox/automation.h
+++ b/components/truma_inetbox/automation.h
@@ -8,7 +8,7 @@ namespace truma_inetbox {
 
 template<typename... Ts> class HeaterRoomTempAction : public Action<Ts...>, public Parented<TrumaiNetBoxApp> {
  public:
-  TEMPLATABLE_VALUE(u_int8_t, temperature)
+  TEMPLATABLE_VALUE(uint8_t, temperature)
   TEMPLATABLE_VALUE(HeatingMode, heating_mode)
 
   void play(Ts... x) override {
@@ -19,7 +19,7 @@ template<typename... Ts> class HeaterRoomTempAction : public Action<Ts...>, publ
 
 template<typename... Ts> class HeaterWaterTempAction : public Action<Ts...>, public Parented<TrumaiNetBoxApp> {
  public:
-  TEMPLATABLE_VALUE(u_int8_t, temperature)
+  TEMPLATABLE_VALUE(uint8_t, temperature)
 
   void play(Ts... x) override {
     this->parent_->get_heater()->action_heater_water(this->temperature_.value_or(x..., 0));
@@ -37,7 +37,7 @@ template<typename... Ts> class HeaterWaterTempEnumAction : public Action<Ts...>,
 
 template<typename... Ts> class HeaterElecPowerLevelAction : public Action<Ts...>, public Parented<TrumaiNetBoxApp> {
  public:
-  TEMPLATABLE_VALUE(u_int16_t, watt)
+  TEMPLATABLE_VALUE(uint16_t, watt)
 
   void play(Ts... x) override {
     this->parent_->get_heater()->action_heater_electric_power_level(this->watt_.value_or(x..., 0));
@@ -58,7 +58,7 @@ template<typename... Ts> class HeaterEnergyMixAction : public Action<Ts...>, pub
 
 template<typename... Ts> class AirconManualTempAction : public Action<Ts...>, public Parented<TrumaiNetBoxApp> {
  public:
-  TEMPLATABLE_VALUE(u_int8_t, temperature)
+  TEMPLATABLE_VALUE(uint8_t, temperature)
 
   void play(Ts... x) override {
     this->parent_->get_aircon_manual()->action_set_temp(this->temperature_.value_or(x..., 0));
@@ -72,11 +72,11 @@ template<typename... Ts> class TimerDisableAction : public Action<Ts...>, public
 
 template<typename... Ts> class TimerActivateAction : public Action<Ts...>, public Parented<TrumaiNetBoxApp> {
  public:
-  TEMPLATABLE_VALUE(u_int16_t, start)
-  TEMPLATABLE_VALUE(u_int16_t, stop)
-  TEMPLATABLE_VALUE(u_int8_t, room_temperature)
+  TEMPLATABLE_VALUE(uint16_t, start)
+  TEMPLATABLE_VALUE(uint16_t, stop)
+  TEMPLATABLE_VALUE(uint8_t, room_temperature)
   TEMPLATABLE_VALUE(HeatingMode, heating_mode)
-  TEMPLATABLE_VALUE(u_int8_t, water_temperature)
+  TEMPLATABLE_VALUE(uint8_t, water_temperature)
   TEMPLATABLE_VALUE(EnergyMix, energy_mix)
   TEMPLATABLE_VALUE(ElectricPowerLevel, watt)
 

--- a/components/truma_inetbox/climate/TrumaRoomClimate.cpp
+++ b/components/truma_inetbox/climate/TrumaRoomClimate.cpp
@@ -131,13 +131,15 @@ climate::ClimateTraits TrumaRoomClimate::traits() {
   // The capabilities of the climate device
   auto traits = climate::ClimateTraits();
   traits.set_supports_current_temperature(true);
-  traits.set_supported_modes({climate::CLIMATE_MODE_OFF, climate::CLIMATE_MODE_HEAT});
+  traits.set_supported_modes({this->supported_modes_});
+
   traits.set_supported_fan_modes({{
       climate::CLIMATE_FAN_OFF,
       climate::CLIMATE_FAN_LOW,
       climate::CLIMATE_FAN_MEDIUM,
       climate::CLIMATE_FAN_HIGH,
   }});
+  
   // traits.set_supported_presets({{
   //     climate::CLIMATE_PRESET_NONE,
   //     climate::CLIMATE_PRESET_ECO,
@@ -149,5 +151,10 @@ climate::ClimateTraits TrumaRoomClimate::traits() {
   traits.set_visual_temperature_step(1);
   return traits;
 }
+  
+void TrumaRoomClimate::set_supported_modes(const std::set<climate::ClimateMode> &modes) {
+  this->supported_modes_ = modes;
+}
+
 }  // namespace truma_inetbox
 }  // namespace esphome

--- a/components/truma_inetbox/climate/TrumaRoomClimate.cpp
+++ b/components/truma_inetbox/climate/TrumaRoomClimate.cpp
@@ -50,7 +50,7 @@ void TrumaRoomClimate::dump_config() { LOG_CLIMATE(TAG, "Truma Room Climate", th
 void TrumaRoomClimate::control(const climate::ClimateCall &call) {
   if (call.get_target_temperature().has_value() && !call.get_fan_mode().has_value()) {
     float temp = *call.get_target_temperature();
-    this->parent_->get_heater()->action_heater_room(static_cast<u_int8_t>(temp));
+    this->parent_->get_heater()->action_heater_room(static_cast<uint8_t>(temp));
   }
 
   if (call.get_mode().has_value()) {
@@ -89,13 +89,13 @@ void TrumaRoomClimate::control(const climate::ClimateCall &call) {
     }
     switch (fan_mode) {
       case climate::CLIMATE_FAN_LOW:
-        this->parent_->get_heater()->action_heater_room(static_cast<u_int8_t>(temp), HeatingMode::HEATING_MODE_ECO);
+        this->parent_->get_heater()->action_heater_room(static_cast<uint8_t>(temp), HeatingMode::HEATING_MODE_ECO);
         break;
       case climate::CLIMATE_FAN_MEDIUM:
-        this->parent_->get_heater()->action_heater_room(static_cast<u_int8_t>(temp), HeatingMode::HEATING_MODE_HIGH);
+        this->parent_->get_heater()->action_heater_room(static_cast<uint8_t>(temp), HeatingMode::HEATING_MODE_HIGH);
         break;
       case climate::CLIMATE_FAN_HIGH:
-        this->parent_->get_heater()->action_heater_room(static_cast<u_int8_t>(temp), HeatingMode::HEATING_MODE_BOOST);
+        this->parent_->get_heater()->action_heater_room(static_cast<uint8_t>(temp), HeatingMode::HEATING_MODE_BOOST);
         break;
       default:
         this->parent_->get_heater()->action_heater_room(0);

--- a/components/truma_inetbox/climate/TrumaRoomClimate.h
+++ b/components/truma_inetbox/climate/TrumaRoomClimate.h
@@ -1,22 +1,33 @@
 #pragma once
 
 #include "esphome/components/climate/climate.h"
+#include "esphome/core/component.h"
 #include "esphome/components/truma_inetbox/TrumaiNetBoxApp.h"
 
 namespace esphome {
-namespace truma_inetbox {
-class TrumaRoomClimate : public Component, public climate::Climate, public Parented<TrumaiNetBoxApp> {
- public:
-  void setup() override;
+  namespace truma_inetbox {
+  
+  class TrumaRoomClimate : public Component, public climate::Climate, public Parented<TrumaiNetBoxApp> {
+   public:
+    void loop() override {}
+    void dump_config() override;
+    void control(const climate::ClimateCall &call) override;
+    void setup() override;
+    climate::ClimateTraits traits() override;
+  
+  
+    void set_visual_min_temperature(float value) { this->visual_min_temperature_ = value; }
+    void set_visual_max_temperature(float value) { this->visual_max_temperature_ = value; }
+    void set_visual_temperature_step(float value) { this->visual_temperature_step_ = value; }
 
-  void dump_config() override;
-
-  void control(const climate::ClimateCall &call) override;
-
-  climate::ClimateTraits traits() override;
-
- protected:
- private:
-};
-}  // namespace truma_inetbox
-}  // namespace esphome
+    void set_supported_modes(const std::set<climate::ClimateMode> &modes);
+  
+   protected:
+    std::set<esphome::climate::ClimateMode> supported_modes_;
+    float visual_min_temperature_{5.0};
+    float visual_max_temperature_{30.0};
+    float visual_temperature_step_{0.5};
+  };
+  
+  }  // namespace truma_inetbox
+  }  // namespace esphome

--- a/components/truma_inetbox/climate/TrumaWaterClimate.cpp
+++ b/components/truma_inetbox/climate/TrumaWaterClimate.cpp
@@ -45,11 +45,16 @@ climate::ClimateTraits TrumaWaterClimate::traits() {
   // The capabilities of the climate device
   auto traits = climate::ClimateTraits();
   traits.set_supports_current_temperature(true);
-  traits.set_supported_modes({climate::CLIMATE_MODE_OFF, climate::CLIMATE_MODE_HEAT});
+  traits.set_supported_modes(this->supported_modes_);
   traits.set_visual_min_temperature(40);
   traits.set_visual_max_temperature(80);
   traits.set_visual_temperature_step(20);
   return traits;
 }
+
+void TrumaWaterClimate::set_supported_modes(const std::set<climate::ClimateMode> &modes) {
+  this->supported_modes_ = modes;
+}
+
 }  // namespace truma_inetbox
 }  // namespace esphome

--- a/components/truma_inetbox/climate/TrumaWaterClimate.cpp
+++ b/components/truma_inetbox/climate/TrumaWaterClimate.cpp
@@ -22,7 +22,7 @@ void TrumaWaterClimate::dump_config() { LOG_CLIMATE(TAG, "Truma Climate", this);
 void TrumaWaterClimate::control(const climate::ClimateCall &call) {
   if (call.get_target_temperature().has_value()) {
     float temp = *call.get_target_temperature();
-    this->parent_->get_heater()->action_heater_water(static_cast<u_int8_t>(temp));
+    this->parent_->get_heater()->action_heater_water(static_cast<uint8_t>(temp));
   }
 
   if (call.get_mode().has_value()) {

--- a/components/truma_inetbox/climate/TrumaWaterClimate.h
+++ b/components/truma_inetbox/climate/TrumaWaterClimate.h
@@ -14,8 +14,10 @@ class TrumaWaterClimate : public Component, public climate::Climate, public Pare
   void control(const climate::ClimateCall &call) override;
 
   climate::ClimateTraits traits() override;
+  void set_supported_modes(const std::set<climate::ClimateMode> &modes);
 
  protected:
+ std::set<esphome::climate::ClimateMode> supported_modes_;
  private:
 };
 }  // namespace truma_inetbox

--- a/components/truma_inetbox/climate/__init__.py
+++ b/components/truma_inetbox/climate/__init__.py
@@ -50,24 +50,20 @@ def set_default_based_on_type():
     return set_defaults_
 
 
-CONFIG_SCHEMA = cv.All(
-    climate.climate_schema(TrumaClimate)
-    .extend(
-        {
-    cv.GenerateID(): cv.declare_id(TrumaClimate),
-    cv.GenerateID(CONF_TRUMA_INETBOX_ID): cv.use_id(TrumaINetBoxApp),
-    cv.Required(CONF_TYPE): cv.enum(CONF_SUPPORTED_TYPE, upper=True),
-
-    cv.Optional(CONF_NAME, default="Truma Climate"): cv.string,
-
-    cv.Optional("preset"): cv.All(cv.ensure_list(cv.string)),  # If you want presets
-    cv.Optional("supported_modes", default=["OFF", "HEAT"]): cv.ensure_list(cv.enum(CLIMATE_MODES, upper=True)),
-}).extend(cv.COMPONENT_SCHEMA).extend({
-    cv.Optional("disabled_by_default", default=False): cv.boolean,
-    cv.Optional("entity_category"): cv.entity_category,
-    cv.Optional("icon"): cv.icon,
-    cv.Optional(CONF_VISUAL, default={}): CLIMATE_VISUAL_SCHEMA,
-})
+CONFIG_SCHEMA = cv.Schema(
+    climate.climate_schema(TrumaClimate).extend({
+        cv.GenerateID(): cv.declare_id(TrumaClimate),
+        cv.GenerateID(CONF_TRUMA_INETBOX_ID): cv.use_id(TrumaINetBoxApp),
+        cv.Required(CONF_TYPE): cv.enum(CONF_SUPPORTED_TYPE, upper=True),
+        cv.Optional(CONF_NAME, default="Truma Climate"): cv.string,
+        cv.Optional("preset"): cv.All(cv.ensure_list(cv.string)),  # If you want presets
+        cv.Optional("supported_modes", default=["OFF", "HEAT"]): cv.ensure_list(cv.enum(CLIMATE_MODES, upper=True)),
+    }).extend(cv.COMPONENT_SCHEMA).extend({
+        cv.Optional("disabled_by_default", default=False): cv.boolean,
+        cv.Optional("entity_category"): cv.entity_category,
+        cv.Optional("icon"): cv.icon,
+        cv.Optional(CONF_VISUAL, default={}): CLIMATE_VISUAL_SCHEMA,
+    })
 )
 
 FINAL_VALIDATE_SCHEMA = set_default_based_on_type()

--- a/components/truma_inetbox/climate/__init__.py
+++ b/components/truma_inetbox/climate/__init__.py
@@ -50,7 +50,10 @@ def set_default_based_on_type():
     return set_defaults_
 
 
-CONFIG_SCHEMA = cv.Schema({
+CONFIG_SCHEMA = cv.All(
+    climate.climate_schema(TrumaClimate)
+    .extend(
+        {
     cv.GenerateID(): cv.declare_id(TrumaClimate),
     cv.GenerateID(CONF_TRUMA_INETBOX_ID): cv.use_id(TrumaINetBoxApp),
     cv.Required(CONF_TYPE): cv.enum(CONF_SUPPORTED_TYPE, upper=True),
@@ -65,6 +68,7 @@ CONFIG_SCHEMA = cv.Schema({
     cv.Optional("icon"): cv.icon,
     cv.Optional(CONF_VISUAL, default={}): CLIMATE_VISUAL_SCHEMA,
 })
+)
 
 FINAL_VALIDATE_SCHEMA = set_default_based_on_type()
 

--- a/components/truma_inetbox/climate/__init__.py
+++ b/components/truma_inetbox/climate/__init__.py
@@ -4,7 +4,29 @@ import esphome.codegen as cg
 from esphome.const import (
     CONF_ID,
     CONF_TYPE,
+    CONF_NAME,
+    CONF_VISUAL,
+    CONF_TARGET_TEMPERATURE,
+    CONF_MIN_TEMPERATURE,
+    CONF_MAX_TEMPERATURE,
+    CONF_TEMPERATURE_STEP,
 )
+from esphome.components.climate import (
+    ClimateMode,
+)
+
+CLIMATE_MODES = {
+    "OFF": ClimateMode.CLIMATE_MODE_OFF,
+    "HEAT": ClimateMode.CLIMATE_MODE_HEAT,
+    "AUTO": ClimateMode.CLIMATE_MODE_AUTO,
+}
+CLIMATE_VISUAL_SCHEMA = cv.Schema({
+    cv.Optional(CONF_TARGET_TEMPERATURE, default={}): cv.Schema({
+        cv.Optional(CONF_MIN_TEMPERATURE, default=5.0): cv.float_,
+        cv.Optional(CONF_MAX_TEMPERATURE, default=30.0): cv.float_,
+        cv.Optional(CONF_TEMPERATURE_STEP, default=0.5): cv.float_,
+    })
+})
 from .. import truma_inetbox_ns, CONF_TRUMA_INETBOX_ID, TrumaINetBoxApp
 
 DEPENDENCIES = ["truma_inetbox"]
@@ -28,13 +50,22 @@ def set_default_based_on_type():
     return set_defaults_
 
 
-CONFIG_SCHEMA = climate.CLIMATE_SCHEMA.extend(
-    {
-        cv.GenerateID(): cv.declare_id(TrumaClimate),
-        cv.GenerateID(CONF_TRUMA_INETBOX_ID): cv.use_id(TrumaINetBoxApp),
-        cv.Required(CONF_TYPE): cv.enum(CONF_SUPPORTED_TYPE, upper=True),
-    }
-).extend(cv.COMPONENT_SCHEMA)
+CONFIG_SCHEMA = cv.Schema({
+    cv.GenerateID(): cv.declare_id(TrumaClimate),
+    cv.GenerateID(CONF_TRUMA_INETBOX_ID): cv.use_id(TrumaINetBoxApp),
+    cv.Required(CONF_TYPE): cv.enum(CONF_SUPPORTED_TYPE, upper=True),
+
+    cv.Optional(CONF_NAME, default="Truma Climate"): cv.string,
+
+    cv.Optional("preset"): cv.All(cv.ensure_list(cv.string)),  # If you want presets
+    cv.Optional("supported_modes", default=["OFF", "HEAT"]): cv.ensure_list(cv.enum(CLIMATE_MODES, upper=True)),
+}).extend(cv.COMPONENT_SCHEMA).extend({
+    cv.Optional("disabled_by_default", default=False): cv.boolean,
+    cv.Optional("entity_category"): cv.entity_category,
+    cv.Optional("icon"): cv.icon,
+    cv.Optional(CONF_VISUAL, default={}): CLIMATE_VISUAL_SCHEMA,
+})
+
 FINAL_VALIDATE_SCHEMA = set_default_based_on_type()
 
 
@@ -43,3 +74,15 @@ async def to_code(config):
     await cg.register_component(var, config)
     await climate.register_climate(var, config)
     await cg.register_parented(var, config[CONF_TRUMA_INETBOX_ID])
+
+    # Optional visual settings
+    #if "visual" in config:
+    #    visual = config["visual"]
+    #    cg.add(var.set_visual_min_temperature(visual["min_temperature"]))
+    #    cg.add(var.set_visual_max_temperature(visual["max_temperature"]))
+    #    cg.add(var.set_visual_temperature_step(visual["temperature_step"]))
+
+    # Optional supported modes
+    if "supported_modes" in config:
+        modes = [CLIMATE_MODES[m] for m in config["supported_modes"]]
+        cg.add(var.set_supported_modes(modes))

--- a/components/truma_inetbox/helpers.cpp
+++ b/components/truma_inetbox/helpers.cpp
@@ -3,15 +3,15 @@
 namespace esphome {
 namespace truma_inetbox {
 
-u_int8_t addr_parity(const u_int8_t PID) {
-  u_int8_t P0 = ((PID >> 0) + (PID >> 1) + (PID >> 2) + (PID >> 4)) & 1;
-  u_int8_t P1 = ~((PID >> 1) + (PID >> 3) + (PID >> 4) + (PID >> 5)) & 1;
+uint8_t addr_parity(const uint8_t PID) {
+  uint8_t P0 = ((PID >> 0) + (PID >> 1) + (PID >> 2) + (PID >> 4)) & 1;
+  uint8_t P1 = ~((PID >> 1) + (PID >> 3) + (PID >> 4) + (PID >> 5)) & 1;
   return (P0 | (P1 << 1));
 }
 
 // sum = 0 LIN 1.X CRC, sum = PID LIN 2.X CRC Enhanced
-u_int8_t data_checksum(const u_int8_t *message, u_int8_t length, uint16_t sum) {
-  for (u_int8_t i = 0; i < length; i++) {
+uint8_t data_checksum(const uint8_t *message, uint8_t length, uint16_t sum) {
+  for (uint8_t i = 0; i < length; i++) {
     sum += message[i];
 
     if (sum >= 256)
@@ -20,7 +20,7 @@ u_int8_t data_checksum(const u_int8_t *message, u_int8_t length, uint16_t sum) {
   return (~sum);
 }
 
-float temp_code_to_decimal(u_int16_t val, float zero) {
+float temp_code_to_decimal(uint16_t val, float zero) {
   if (val == 0) {
     return zero;
   }
@@ -34,13 +34,13 @@ float water_temp_200_fix(float val) {
   return val;
 }
 
-float temp_code_to_decimal(TargetTemp val, float zero) { return temp_code_to_decimal((u_int16_t) val, zero); }
+float temp_code_to_decimal(TargetTemp val, float zero) { return temp_code_to_decimal((uint16_t) val, zero); }
 
-TargetTemp decimal_to_temp(u_int8_t val) { return (TargetTemp) ((((u_int16_t) val) + 273) * 10); }
+TargetTemp decimal_to_temp(uint8_t val) { return (TargetTemp) ((((uint16_t) val) + 273) * 10); }
 
 TargetTemp decimal_to_temp(float val) { return (TargetTemp) ((val + 273) * 10); }
 
-TargetTemp decimal_to_room_temp(u_int8_t val) {
+TargetTemp decimal_to_room_temp(uint8_t val) {
   if (val == 0) {
     return TargetTemp::TARGET_TEMP_OFF;
   }
@@ -66,7 +66,7 @@ TargetTemp decimal_to_room_temp(float val) {
   return decimal_to_temp(val);
 }
 
-TargetTemp decimal_to_aircon_manual_temp(u_int8_t val) {
+TargetTemp decimal_to_aircon_manual_temp(uint8_t val) {
   if (val == 0) {
     return TargetTemp::TARGET_TEMP_OFF;
   }
@@ -92,7 +92,7 @@ TargetTemp decimal_to_aircon_manual_temp(float val) {
   return decimal_to_temp(val);
 }
 
-TargetTemp decimal_to_aircon_auto_temp(u_int8_t val) {
+TargetTemp decimal_to_aircon_auto_temp(uint8_t val) {
   if (val == 0) {
     return TargetTemp::TARGET_TEMP_OFF;
   }
@@ -118,7 +118,7 @@ TargetTemp decimal_to_aircon_auto_temp(float val) {
   return decimal_to_temp(val);
 }
 
-TargetTemp decimal_to_water_temp(u_int8_t val) {
+TargetTemp decimal_to_water_temp(uint8_t val) {
   if (val < 40) {
     return TargetTemp::TARGET_TEMP_OFF;
   } else if (val >= 40 && val < 60) {
@@ -164,7 +164,7 @@ const std::string operating_status_to_str(OperatingStatus val) {
   }
 }
 
-ElectricPowerLevel decimal_to_el_power_level(u_int16_t val) {
+ElectricPowerLevel decimal_to_el_power_level(uint16_t val) {
   if (val >= 1800) {
     return ElectricPowerLevel::ELECTRIC_POWER_LEVEL_1800;
   } else if (val >= 900) {

--- a/components/truma_inetbox/helpers.h
+++ b/components/truma_inetbox/helpers.h
@@ -8,27 +8,27 @@ namespace truma_inetbox {
 // First byte is service identifier and to be ignored. Last three bytes can be `xFF` or `x00` (see
 // <https://github.com/Fabian-Schmidt/esphome-truma_inetbox/issues/25>).
 // `truma_message_header` and `alde_message_header` must have the same size!
-const std::array<u_int8_t, 11> truma_message_header = {0x00, 0x00, 0x1F, 0x00, 0x1E, 0x00,
+const std::array<uint8_t, 11> truma_message_header = {0x00, 0x00, 0x1F, 0x00, 0x1E, 0x00,
                                                        0x00, 0x22, 0xFF, 0xFF, 0xFF};
-const std::array<u_int8_t, 11> alde_message_header = {0x00, 0x00, 0x1F, 0x00, 0x1A, 0x00, 0x00, 0x22, 0xFF, 0xFF, 0xFF};
+const std::array<uint8_t, 11> alde_message_header = {0x00, 0x00, 0x1F, 0x00, 0x1A, 0x00, 0x00, 0x22, 0xFF, 0xFF, 0xFF};
 
-u_int8_t addr_parity(const u_int8_t pid);
-u_int8_t data_checksum(const u_int8_t *message, u_int8_t length, uint16_t sum);
-float temp_code_to_decimal(u_int16_t val, float zero = NAN);
+uint8_t addr_parity(const uint8_t pid);
+uint8_t data_checksum(const uint8_t *message, uint8_t length, uint16_t sum);
+float temp_code_to_decimal(uint16_t val, float zero = NAN);
 float temp_code_to_decimal(TargetTemp val, float zero = NAN);
 float water_temp_200_fix(float val);
-TargetTemp decimal_to_temp(u_int8_t val);
+TargetTemp decimal_to_temp(uint8_t val);
 TargetTemp decimal_to_temp(float val);
-TargetTemp decimal_to_room_temp(u_int8_t val);
+TargetTemp decimal_to_room_temp(uint8_t val);
 TargetTemp decimal_to_room_temp(float val);
-TargetTemp decimal_to_aircon_manual_temp(u_int8_t val);
+TargetTemp decimal_to_aircon_manual_temp(uint8_t val);
 TargetTemp decimal_to_aircon_manual_temp(float val);
-TargetTemp decimal_to_aircon_auto_temp(u_int8_t val);
+TargetTemp decimal_to_aircon_auto_temp(uint8_t val);
 TargetTemp decimal_to_aircon_auto_temp(float val);
-TargetTemp decimal_to_water_temp(u_int8_t val);
+TargetTemp decimal_to_water_temp(uint8_t val);
 TargetTemp decimal_to_water_temp(float val);
 const std::string operating_status_to_str(OperatingStatus val);
-ElectricPowerLevel decimal_to_el_power_level(u_int16_t val);
+ElectricPowerLevel decimal_to_el_power_level(uint16_t val);
 
 }  // namespace truma_inetbox
 }  // namespace esphome

--- a/components/truma_inetbox/number/TrumaAirconManualNumber.cpp
+++ b/components/truma_inetbox/number/TrumaAirconManualNumber.cpp
@@ -22,7 +22,7 @@ void TrumaAirconManualNumber::setup() {
 void TrumaAirconManualNumber::control(float value) {
   switch (this->type_) {
     case TRUMA_NUMBER_TYPE::AIRCON_MANUAL_TEMPERATURE:
-      this->parent_->get_aircon_manual()->action_set_temp(static_cast<u_int8_t>(value));
+      this->parent_->get_aircon_manual()->action_set_temp(static_cast<uint8_t>(value));
       break;
     default:
       break;

--- a/components/truma_inetbox/number/TrumaHeaterNumber.cpp
+++ b/components/truma_inetbox/number/TrumaHeaterNumber.cpp
@@ -28,13 +28,13 @@ void TrumaHeaterNumber::setup() {
 void TrumaHeaterNumber::control(float value) {
   switch (this->type_) {
     case TRUMA_NUMBER_TYPE::TARGET_ROOM_TEMPERATURE:
-      this->parent_->get_heater()->action_heater_room(static_cast<u_int8_t>(value));
+      this->parent_->get_heater()->action_heater_room(static_cast<uint8_t>(value));
       break;
     case TRUMA_NUMBER_TYPE::TARGET_WATER_TEMPERATURE:
-      this->parent_->get_heater()->action_heater_water(static_cast<u_int8_t>(value));
+      this->parent_->get_heater()->action_heater_water(static_cast<uint8_t>(value));
       break;
     case TRUMA_NUMBER_TYPE::ELECTRIC_POWER_LEVEL:
-      this->parent_->get_heater()->action_heater_electric_power_level(static_cast<u_int16_t>(value));
+      this->parent_->get_heater()->action_heater_electric_power_level(static_cast<uint16_t>(value));
       break;
     default:
       break;

--- a/components/truma_inetbox/select/TrumaHeaterSelect.cpp
+++ b/components/truma_inetbox/select/TrumaHeaterSelect.cpp
@@ -94,23 +94,23 @@ void TrumaHeaterSelect::control(const std::string &value) {
         case TRUMA_SELECT_TYPE_HEATER_FAN_MODE::ECO:
           // case TRUMA_SELECT_TYPE_HEATER_FAN_MODE::VARIO_HEAT_NIGHT:
           if (heater_device == TRUMA_DEVICE::CPPLUS_VARIO) {
-            this->parent_->get_heater()->action_heater_room(static_cast<u_int8_t>(temp),
+            this->parent_->get_heater()->action_heater_room(static_cast<uint8_t>(temp),
                                                          HeatingMode::HEATING_MODE_VARIO_HEAT_NIGHT);
           } else {
-            this->parent_->get_heater()->action_heater_room(static_cast<u_int8_t>(temp), HeatingMode::HEATING_MODE_ECO);
+            this->parent_->get_heater()->action_heater_room(static_cast<uint8_t>(temp), HeatingMode::HEATING_MODE_ECO);
           }
           break;
         case TRUMA_SELECT_TYPE_HEATER_FAN_MODE::COMBI_HIGH:
           // case TRUMA_SELECT_TYPE_HEATER_FAN_MODE::VARIO_HEAT_AUTO:
           if (heater_device == TRUMA_DEVICE::CPPLUS_VARIO) {
-            this->parent_->get_heater()->action_heater_room(static_cast<u_int8_t>(temp),
+            this->parent_->get_heater()->action_heater_room(static_cast<uint8_t>(temp),
                                                          HeatingMode::HEATING_MODE_VARIO_HEAT_AUTO);
           } else {
-            this->parent_->get_heater()->action_heater_room(static_cast<u_int8_t>(temp), HeatingMode::HEATING_MODE_HIGH);
+            this->parent_->get_heater()->action_heater_room(static_cast<uint8_t>(temp), HeatingMode::HEATING_MODE_HIGH);
           }
           break;
         case TRUMA_SELECT_TYPE_HEATER_FAN_MODE::BOOST:
-          this->parent_->get_heater()->action_heater_room(static_cast<u_int8_t>(temp), HeatingMode::HEATING_MODE_BOOST);
+          this->parent_->get_heater()->action_heater_room(static_cast<uint8_t>(temp), HeatingMode::HEATING_MODE_BOOST);
           break;
         default:
           this->parent_->get_heater()->action_heater_room(0, HeatingMode::HEATING_MODE_OFF);

--- a/components/truma_inetbox/time/TrumaTime.h
+++ b/components/truma_inetbox/time/TrumaTime.h
@@ -18,7 +18,7 @@ class TrumaTime : public time::RealTimeClock, public Parented<TrumaiNetBoxApp> {
 
  protected:
   bool auto_disable_ = false;
-  u_int8_t auto_disable_count_ = 3;
+  uint8_t auto_disable_count_ = 3;
 
  private:
 };

--- a/components/uart/uart_component_esp_idf.cpp
+++ b/components/uart/uart_component_esp_idf.cpp
@@ -149,7 +149,7 @@ bool IDFUARTComponent::peek_byte(uint8_t *data) {
   if (this->has_peek_) {
     *data = this->peek_byte_;
   } else {
-    int len = uart_read_bytes(this->uart_num_, data, 1, 20 / portTICK_RATE_MS);
+    int len = uart_read_bytes(this->uart_num_, data, 1, 20 / portTICK_PERIOD_MS);
     if (len == 0) {
       *data = 0;
     } else {
@@ -173,7 +173,7 @@ bool IDFUARTComponent::read_array(uint8_t *data, size_t len) {
     this->has_peek_ = false;
   }
   if (length_to_read > 0)
-    uart_read_bytes(this->uart_num_, data, length_to_read, 20 / portTICK_RATE_MS);
+    uart_read_bytes(this->uart_num_, data, length_to_read, 20 / portTICK_PERIOD_MS);
   xSemaphoreGive(this->lock_);
 #ifdef USE_UART_DEBUGGER
   for (size_t i = 0; i < len; i++) {

--- a/components/uart/uart_component_esp_idf.cpp
+++ b/components/uart/uart_component_esp_idf.cpp
@@ -64,7 +64,7 @@ void IDFUARTComponent::setup() {
     this->mark_failed();
     return;
   }
-  this->uart_num_ = next_uart_num++;
+  this->uart_num_ = static_cast<uart_port_t>(next_uart_num++);
   ESP_LOGCONFIG(TAG, "Setting up UART %u...", this->uart_num_);
 
   this->lock_ = xSemaphoreCreateMutex();


### PR DESCRIPTION
Please see fixes for errors that I found when running on esphome in docker container on versions 2024.11 and 2025.9.2. 
includes changes from https://github.com/Fabian-Schmidt/esphome-truma_inetbox/pull/60 for 2025.11 compatibility
changes include:
- https://github.com/Fabian-Schmidt/esphome-truma_inetbox/issues/50 portTICK_RATE_MS -> portTICK_PERIOD_MS portTickType -> TickType_t
- https://github.com/Fabian-Schmidt/esphome-truma_inetbox/issues/62  2025.11 compatibility @juvander
- ensuring climate component for truma inet room and water continues to support full web_server v3 positioning
- errors when compiling due to changes in variable types:
  - u_int8_t -> uint8_t,
  - u_int16_t -> uint16_t
  - u_int32_t -> uint32_t
- compile errors  when casting / assigning uart_num and uart_port_t 